### PR TITLE
Add support for array.size syntax and bugfixes

### DIFF
--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -25,7 +25,7 @@ class CodeGenerator : Closeable {
     private var codegenContext = CodeGenContext()
 
     inner class PrimaryTypes {
-        val integerType: LLVMTypeRef = LLVMInt64TypeInContext(llvmContext)
+        val integerType: LLVMTypeRef = LLVMInt32TypeInContext(llvmContext)
         val doubleType: LLVMTypeRef = LLVMDoubleTypeInContext(llvmContext)
         val boolType: LLVMTypeRef = LLVMInt1TypeInContext(llvmContext)
         val voidType: LLVMTypeRef = LLVMVoidTypeInContext(llvmContext)
@@ -499,7 +499,6 @@ class CodeGenerator : Closeable {
 
     private fun getPointerToArrayElement(arrayAccess: ArrayAccessExpression): LLVMValueRef {
         val elemType = arrayAccess.arrayType.contentType.llvmType
-        val arrayType = types.pointerType
 
         val arrayWrapperPtrAlloca = processAccessExpressionAsLhs(arrayAccess.accessedExpression)
         val arrayPtr = LLVMBuildStructGEP2(builder, types.arrayWrapperType, arrayWrapperPtrAlloca, 1, "array-ptr")
@@ -514,7 +513,7 @@ class CodeGenerator : Closeable {
         return LLVMBuildGEP2(
             builder,
             elemType,
-            loadArray,
+            loadArrayPtr,
             idxPointerPointer,
             1,
             "array-access"

--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -25,7 +25,7 @@ class CodeGenerator : Closeable {
     private var codegenContext = CodeGenContext()
 
     inner class PrimaryTypes {
-        val integerType: LLVMTypeRef = LLVMInt32TypeInContext(llvmContext)
+        val integerType: LLVMTypeRef = LLVMInt64TypeInContext(llvmContext)
         val doubleType: LLVMTypeRef = LLVMDoubleTypeInContext(llvmContext)
         val boolType: LLVMTypeRef = LLVMInt1TypeInContext(llvmContext)
         val voidType: LLVMTypeRef = LLVMVoidTypeInContext(llvmContext)
@@ -263,7 +263,7 @@ class CodeGenerator : Closeable {
                 val sizeInElements = type.size!!.toLong()
                 val arraySizeInBytes = LLVMConstInt(
                     types.integerType,
-                    type.sizeof,
+                    sizeInElements,
                     /* SignExtend = */ 0)
 
                 val wrapperAlloc = LLVMBuildAlloca(builder, types.arrayWrapperType, "array-wrapper-alloca")
@@ -499,7 +499,7 @@ class CodeGenerator : Closeable {
 
     private fun getPointerToArrayElement(arrayAccess: ArrayAccessExpression): LLVMValueRef {
         val elemType = arrayAccess.arrayType.contentType.llvmType
-        val arrayType = LLVMPointerTypeInContext(llvmContext, 0)
+        val arrayType = types.pointerType
 
         val arrayWrapperPtrAlloca = processAccessExpressionAsLhs(arrayAccess.accessedExpression)
         val arrayWrapperAlloca = LLVMBuildLoad2(builder, types.pointerType, arrayWrapperPtrAlloca, "load-wrapper")

--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -600,13 +600,13 @@ class CodeGenerator : Closeable {
     private fun processRoutineCall(call: RoutineCall): LLVMValueRef {
         val routineSignature = call.routineDeclaration.signatureType
         val routineName = call.routineDeclaration.name
-        val routineType = call.routineDeclaration.type.returnType
+        val routineReturnType = call.routineDeclaration.type.returnType
         val function = LLVMGetNamedFunction(module, routineName)
 
         val args = call.arguments.asCallArgValues
 
         // we should pass no instruction name if its return type is void
-        val callInstrName = if (routineType !is UnitType) {
+        val callInstrName = if (routineReturnType !is UnitType) {
             routineName + "_call"
         } else {
             ""
@@ -639,7 +639,7 @@ class CodeGenerator : Closeable {
         return when (expression) {
             is ArrayAccessExpression -> processAccessExpressionAsLhs(expression)
             is VariableAccessExpression -> {
-                if (expression.type is RecordType || expression.type is ArrayType) {
+                if (expression.type is UserType) {
                     processAccessExpressionAsLhs(expression)
                 } else {
                     processExpression(expression)

--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -274,7 +274,7 @@ class CodeGenerator : Closeable {
                     types.arrayWrapperType,
                     wrapperAlloc,
                     0,
-                    "get-array-ptr-in-wrapper"
+                    "get-size-ptr-in-wrapper"
                 )
 
                 LLVMBuildStore(builder, sizeValue, sizePtr)

--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -502,9 +502,8 @@ class CodeGenerator : Closeable {
         val arrayType = types.pointerType
 
         val arrayWrapperPtrAlloca = processAccessExpressionAsLhs(arrayAccess.accessedExpression)
-        val arrayWrapperAlloca = LLVMBuildLoad2(builder, types.pointerType, arrayWrapperPtrAlloca, "load-wrapper")
-        val arrayPtr = LLVMBuildStructGEP2(builder, types.arrayWrapperType, arrayWrapperAlloca, 1, "array-ptr")
-        val loadArray = LLVMBuildLoad2(builder, arrayType, arrayPtr, "load-arr")
+        val arrayPtr = LLVMBuildStructGEP2(builder, types.arrayWrapperType, arrayWrapperPtrAlloca, 1, "array-ptr")
+        val loadArrayPtr = LLVMBuildLoad2(builder, types.pointerType, arrayPtr, "load-arr")
 
         // as far as our array indexes starts with 1, we need to subtract 1 from it
         val idx = processExpression(arrayAccess.indexExpression!!)

--- a/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/edu/itmo/ilang/codegen/CodeGenerator.kt
@@ -290,7 +290,7 @@ class CodeGenerator : Closeable {
 
                 LLVMBuildStore(builder, arrayMalloc, arrayPtr)
 
-                wrapperAlloc
+                LLVMBuildLoad2(builder, types.arrayWrapperType, wrapperAlloc, "load-wrapper")
             }
 
             is RecordType -> {
@@ -724,9 +724,9 @@ class CodeGenerator : Closeable {
         val iterLoad = LLVMBuildLoad2(builder, types.integerType, iteratorAlloca, "iter-load")
 
         val condition = if (statement.isReversed) {
-            LLVMBuildICmp(builder, LLVMIntSGE, iterLoad, stopValue, "cmp-forward")
+            LLVMBuildICmp(builder, LLVMIntSGE, iterLoad, stopValue, "cmp-reverse")
         } else {
-            LLVMBuildICmp(builder, LLVMIntSLE, iterLoad, stopValue, "cmp-reverse")
+            LLVMBuildICmp(builder, LLVMIntSLE, iterLoad, stopValue, "cmp-forward")
         }
 
         LLVMBuildCondBr(builder, condition, loopBodyBlock, exitBlock)

--- a/src/main/kotlin/edu/itmo/ilang/semantic/SemanticStageProcessor.kt
+++ b/src/main/kotlin/edu/itmo/ilang/semantic/SemanticStageProcessor.kt
@@ -2,7 +2,10 @@ package edu.itmo.ilang.semantic
 
 import edu.itmo.ilang.ir.Program
 import edu.itmo.ilang.semantic.analysis.FunctionReturnAnalyzer
-import edu.itmo.ilang.semantic.checkers.*
+import edu.itmo.ilang.semantic.checkers.AssignNewValueToArgument
+import edu.itmo.ilang.semantic.checkers.BreakAndContinueInsideCyclesChecker
+import edu.itmo.ilang.semantic.checkers.ForRangeIsInteger
+import edu.itmo.ilang.semantic.checkers.FunctionReturnChecker
 import edu.itmo.ilang.semantic.transformations.DeadCodeEliminator
 
 class SemanticStageProcessor {
@@ -12,6 +15,7 @@ class SemanticStageProcessor {
 
     private val checkers = listOf(
 //        TypeChecker(), todo: enable when it will be implemented
+//        ArraySizeModificationIsProhibited(), todo: enable when it will be implemented
         FunctionReturnChecker(),
         BreakAndContinueInsideCyclesChecker(),
         AssignNewValueToArgument(),

--- a/src/main/kotlin/edu/itmo/ilang/semantic/checkers/ArraySizeModificationIsProhibited.kt
+++ b/src/main/kotlin/edu/itmo/ilang/semantic/checkers/ArraySizeModificationIsProhibited.kt
@@ -1,0 +1,20 @@
+package edu.itmo.ilang.semantic.checkers
+
+import edu.itmo.ilang.ir.Program
+
+/**
+ * todo: deny array size setting like this:
+ * In current implementation the next code is valid:
+ *
+ * routine test() : integer is
+ *   var arr1 : array[1] integer
+ *   arr1.size := 10
+ *
+ *   return arr1.size // 10
+ * end
+ */
+class ArraySizeModificationIsProhibited : Checker {
+    override fun check(program: Program) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/runners/CodeGenTestsRunner.kt
+++ b/src/test/kotlin/runners/CodeGenTestsRunner.kt
@@ -76,7 +76,7 @@ object CodeGenTestsRunner : ParseAwareTestRunner() {
         val argValues = args.split(",").map { it.asValue }
         val argsNotNull = argValues.filterNotNull()
 
-        if (argValues != argsNotNull) {
+        if (args.isNotBlank() && argValues != argsNotNull) {
             return null
         }
 

--- a/src/test/kotlin/runners/CodeGenTestsRunner.kt
+++ b/src/test/kotlin/runners/CodeGenTestsRunner.kt
@@ -38,7 +38,7 @@ object CodeGenTestsRunner : ParseAwareTestRunner() {
 
     private fun LLVMInterpreter.executeFunction(meta: ExecutionMeta): Any? {
         return when (val expectedResult = meta.expectedResult) {
-            is Long -> this.interpretWithIntegerResult(meta.routineName, meta.args)
+            is Int -> this.interpretWithIntegerResult(meta.routineName, meta.args)
             is Boolean -> this.interpretWithBooleanResult(meta.routineName, meta.args)
             is Double -> this.interpretWithRealResult(meta.routineName, meta.args)
             null -> {
@@ -91,11 +91,11 @@ object CodeGenTestsRunner : ParseAwareTestRunner() {
 
     private val String.asValue: Any?
         get() {
-            val asLong = this.toLongOrNull()
+            val asInt = this.toIntOrNull()
             val asDouble = this.toDoubleOrNull()
             val asBoolean = this.toBooleanStrictOrNull()
 
-            return asLong ?: asDouble ?: asBoolean
+            return asInt ?: asDouble ?: asBoolean
         }
 
     data class ExecutionMeta(

--- a/src/test/kotlin/runners/CodeGenTestsRunner.kt
+++ b/src/test/kotlin/runners/CodeGenTestsRunner.kt
@@ -38,7 +38,7 @@ object CodeGenTestsRunner : ParseAwareTestRunner() {
 
     private fun LLVMInterpreter.executeFunction(meta: ExecutionMeta): Any? {
         return when (val expectedResult = meta.expectedResult) {
-            is Int -> this.interpretWithIntegerResult(meta.routineName, meta.args)
+            is Long -> this.interpretWithIntegerResult(meta.routineName, meta.args)
             is Boolean -> this.interpretWithBooleanResult(meta.routineName, meta.args)
             is Double -> this.interpretWithRealResult(meta.routineName, meta.args)
             null -> {
@@ -91,11 +91,11 @@ object CodeGenTestsRunner : ParseAwareTestRunner() {
 
     private val String.asValue: Any?
         get() {
-            val asInt = this.toIntOrNull()
+            val asLong = this.toLongOrNull()
             val asDouble = this.toDoubleOrNull()
             val asBoolean = this.toBooleanStrictOrNull()
 
-            return asInt ?: asDouble ?: asBoolean
+            return asLong ?: asDouble ?: asBoolean
         }
 
     data class ExecutionMeta(

--- a/src/test/kotlin/tests/generated/iLangCodeGenTests.kt
+++ b/src/test/kotlin/tests/generated/iLangCodeGenTests.kt
@@ -127,6 +127,11 @@ class iLangCodeGenTests {
     }
     
     @Test
+    fun return_array_test() {
+        CodeGenTestsRunner.run("return_array")
+    }
+    
+    @Test
     fun return_statements_in_if_branches_test() {
         CodeGenTestsRunner.run("return_statements_in_if_branches")
     }

--- a/src/test/kotlin/tests/generated/iLangCodeGenTests.kt
+++ b/src/test/kotlin/tests/generated/iLangCodeGenTests.kt
@@ -32,6 +32,11 @@ class iLangCodeGenTests {
     }
     
     @Test
+    fun array_size_test() {
+        CodeGenTestsRunner.run("array_size")
+    }
+    
+    @Test
     fun arrays_test() {
         CodeGenTestsRunner.run("arrays")
     }

--- a/src/test/kotlin/tests/generated/iLangIrBuilderTests.kt
+++ b/src/test/kotlin/tests/generated/iLangIrBuilderTests.kt
@@ -32,6 +32,11 @@ class iLangIrBuilderTests {
     }
     
     @Test
+    fun array_size_test() {
+        IrBuilderTestsRunner.run("array_size")
+    }
+    
+    @Test
     fun arrays_test() {
         IrBuilderTestsRunner.run("arrays")
     }

--- a/src/test/kotlin/tests/generated/iLangIrBuilderTests.kt
+++ b/src/test/kotlin/tests/generated/iLangIrBuilderTests.kt
@@ -127,6 +127,11 @@ class iLangIrBuilderTests {
     }
     
     @Test
+    fun return_array_test() {
+        IrBuilderTestsRunner.run("return_array")
+    }
+    
+    @Test
     fun return_statements_in_if_branches_test() {
         IrBuilderTestsRunner.run("return_statements_in_if_branches")
     }

--- a/src/test/kotlin/tests/generated/iLangParserTests.kt
+++ b/src/test/kotlin/tests/generated/iLangParserTests.kt
@@ -32,6 +32,11 @@ class iLangParserTests {
     }
     
     @Test
+    fun array_size_test() {
+        ParserTestsRunner.run("array_size")
+    }
+    
+    @Test
     fun arrays_test() {
         ParserTestsRunner.run("arrays")
     }

--- a/src/test/kotlin/tests/generated/iLangParserTests.kt
+++ b/src/test/kotlin/tests/generated/iLangParserTests.kt
@@ -127,6 +127,11 @@ class iLangParserTests {
     }
     
     @Test
+    fun return_array_test() {
+        ParserTestsRunner.run("return_array")
+    }
+    
+    @Test
     fun return_statements_in_if_branches_test() {
         ParserTestsRunner.run("return_statements_in_if_branches")
     }

--- a/src/test/kotlin/utils/LLVMInterpreter.kt
+++ b/src/test/kotlin/utils/LLVMInterpreter.kt
@@ -17,8 +17,8 @@ class LLVMInterpreter(private val module: LLVMModuleRef) {
     private val engine = LLVMExecutionEngineRef()
     private val options = LLVMMCJITCompilerOptions()
 
-    fun interpretWithIntegerResult(routineName: String, args: List<Any>): Int {
-        return interpret(routineName, args, ValueLayout.JAVA_INT) as Int
+    fun interpretWithIntegerResult(routineName: String, args: List<Any>): Long {
+        return interpret(routineName, args, ValueLayout.JAVA_LONG) as Long
     }
 
     fun interpretWithRealResult(routineName: String, args: List<Any>): Double {
@@ -63,7 +63,7 @@ class LLVMInterpreter(private val module: LLVMModuleRef) {
     private fun getFunctionDescriptor(args: List<Any>, returnLayout: ValueLayout?): FunctionDescriptor {
         val argsLayouts = args.map { arg ->
             when (arg) {
-                is Int -> ValueLayout.JAVA_INT
+                is Long -> ValueLayout.JAVA_LONG
                 is Double -> ValueLayout.JAVA_DOUBLE
                 is Boolean -> ValueLayout.JAVA_BOOLEAN
                 else -> error("can't parse $arg")

--- a/src/test/kotlin/utils/LLVMInterpreter.kt
+++ b/src/test/kotlin/utils/LLVMInterpreter.kt
@@ -17,8 +17,8 @@ class LLVMInterpreter(private val module: LLVMModuleRef) {
     private val engine = LLVMExecutionEngineRef()
     private val options = LLVMMCJITCompilerOptions()
 
-    fun interpretWithIntegerResult(routineName: String, args: List<Any>): Long {
-        return interpret(routineName, args, ValueLayout.JAVA_LONG) as Long
+    fun interpretWithIntegerResult(routineName: String, args: List<Any>): Int {
+        return interpret(routineName, args, ValueLayout.JAVA_INT) as Int
     }
 
     fun interpretWithRealResult(routineName: String, args: List<Any>): Double {
@@ -63,7 +63,7 @@ class LLVMInterpreter(private val module: LLVMModuleRef) {
     private fun getFunctionDescriptor(args: List<Any>, returnLayout: ValueLayout?): FunctionDescriptor {
         val argsLayouts = args.map { arg ->
             when (arg) {
-                is Long -> ValueLayout.JAVA_LONG
+                is Int -> ValueLayout.JAVA_INT
                 is Double -> ValueLayout.JAVA_DOUBLE
                 is Boolean -> ValueLayout.JAVA_BOOLEAN
                 else -> error("can't parse $arg")

--- a/src/test/resources/testdata/array_any_all.il
+++ b/src/test/resources/testdata/array_any_all.il
@@ -1,3 +1,5 @@
+// main(): true
+
 routine not(b : bool) : bool is
     if b then return false else return true end
 end

--- a/src/test/resources/testdata/array_avg.il
+++ b/src/test/resources/testdata/array_avg.il
@@ -1,3 +1,5 @@
+// main(): 3.0
+
 routine avg(arr : array[] integer) : real is
     var sum : integer is 0
 

--- a/src/test/resources/testdata/array_avg.il
+++ b/src/test/resources/testdata/array_avg.il
@@ -5,7 +5,7 @@ routine avg(arr : array[] integer) : real is
         sum := sum + arr[i]
     end
 
-    return sum / arr.size
+    return sum * 1.0 / arr.size
 end
 
 routine main() : real is

--- a/src/test/resources/testdata/array_count.il
+++ b/src/test/resources/testdata/array_count.il
@@ -1,3 +1,5 @@
+// main(): 3
+
 routine count(elem : integer, arr : array[] integer) : integer is
     var res is 0
 

--- a/src/test/resources/testdata/array_linear_search.il
+++ b/src/test/resources/testdata/array_linear_search.il
@@ -26,5 +26,5 @@ routine main() : integer is
     arr[4] := 3
     arr[5] := 1
 
-    return firstIndex(arr, 2) + lastIndex(arr, 3)
+    return firstIndex(2, arr) + lastIndex(3, arr)
 end

--- a/src/test/resources/testdata/array_linear_search.il
+++ b/src/test/resources/testdata/array_linear_search.il
@@ -1,3 +1,5 @@
+// main(): 6
+
 routine firstIndex(elem : integer, arr : array[] integer) : integer is
     for i in 1..(arr.size) loop
         if arr[i] = elem then

--- a/src/test/resources/testdata/array_min_max.il
+++ b/src/test/resources/testdata/array_min_max.il
@@ -1,3 +1,5 @@
+// main(): 6
+
 routine min(arr : array[] integer) : integer is
     var current is arr[1]
 

--- a/src/test/resources/testdata/array_size.il
+++ b/src/test/resources/testdata/array_size.il
@@ -1,0 +1,10 @@
+//array_size_test() : 113
+
+routine array_size_test() : integer is
+  var arr1 : array[1] integer
+  var arr2 : array[2] integer
+  var arr10 : array[10] integer
+  var arr100 : array[100] integer
+
+  return arr1.size + arr2.size + arr10.size + arr100.size
+end

--- a/src/test/resources/testdata/bubble_sort.il
+++ b/src/test/resources/testdata/bubble_sort.il
@@ -1,3 +1,5 @@
+// main(): true
+
 routine bubbleSort(arr : array[] integer) is
     var current is arr[1]
     var temp : integer

--- a/src/test/resources/testdata/fib.il
+++ b/src/test/resources/testdata/fib.il
@@ -1,4 +1,16 @@
+// fib(1): 1
+// fib(2): 1
+// fib(3): 2
+// fib(4): 3
+// fib(5): 5
+// fib(6): 8
+// fib(7): 13
+
 routine fib(n: integer) : integer is
+    if n = 1 then
+        return 1
+    end
+
     var num1 : integer
     num1 := 0
 

--- a/src/test/resources/testdata/gcd.il
+++ b/src/test/resources/testdata/gcd.il
@@ -1,3 +1,8 @@
+// gcd(1, 1): 1
+// gcd(2, 4): 2
+// gcd(17, 11): 1
+// gcd(120, 200): 40
+
 routine gcd(n1 : integer, n2 : integer) : integer is
     var n_1 is n1
     var n_2 is n2

--- a/src/test/resources/testdata/quick_sort.il
+++ b/src/test/resources/testdata/quick_sort.il
@@ -1,3 +1,5 @@
+// main(): true
+
 routine quickSort(arr : array[] integer, low : integer, high : integer) is
     if (arr.size = 0 or low >= high) then
         return
@@ -15,7 +17,7 @@ routine quickSort(arr : array[] integer, low : integer, high : integer) is
             i := i + 1
         end
 
-        while arr[i] > midElement loop
+        while arr[j] > midElement loop
             j := j - 1
         end
 

--- a/src/test/resources/testdata/quick_sort.il
+++ b/src/test/resources/testdata/quick_sort.il
@@ -58,7 +58,7 @@ routine main() : bool is
     arr[3] := 3
     arr[4] := 0
     arr[5] := 1
-    quickSort(arr)
+    quickSort(arr, 1, arr.size)
 
     return isSorted(arr)
 end

--- a/src/test/resources/testdata/return_array.il
+++ b/src/test/resources/testdata/return_array.il
@@ -1,0 +1,21 @@
+// main_(1): 5
+// main_(2): 10
+// main_(3): 15
+
+routine get_array(i : integer) : array[] integer is
+  var arr : array[5] integer
+
+  arr[1] := i
+  arr[2] := i
+  arr[3] := i
+  arr[4] := i
+  arr[5] := i
+
+  return arr
+end
+
+routine main_(i : integer) : integer is
+  var arr : array[] integer is get_array(i)
+
+  return arr[1] + arr[2] + arr[3] + arr[4] + arr[5]
+end


### PR DESCRIPTION
Пришлось нагородить костылей конечно. Но я думаю, что это не очень критично при текущей реализации кодгенератора. Мб когда-нибудь зарефакторю его

Ещё, поправил за одно проблему с рекордами. Теперь они везде хранятся как указатели (в том числе внутри других рекордов — так ушла проблема с SOF)

Проходят 25/27 тестов. Два падают из-за того, что мы не поддерживаем uninitialized. Думаю, сделаю это в следующий раз

<img width="345" alt="image" src="https://github.com/vldF/i-lang-compiler/assets/21011268/a788ae2e-9ccf-4aa4-9a29-401f5df99c56">

